### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+lvstest
+__pycache__


### PR DESCRIPTION
This adds .gitignore to ignore files produced after running `./multi_tool.py`.