### PR TITLE
Fix OpenRAM integration issue

### DIFF
--- a/codegen/caravel_iface_openram.txt
+++ b/codegen/caravel_iface_openram.txt
@@ -129,7 +129,7 @@
         .ram_wmask0 (oram_wmask0[3:0]),
         .ram_addr0 (oram_addr0[7:0]),
         .ram_din0 (oram_din0[31:0]),       
-        .ram_dout0 (oram_din0[31:0]),      
+        .ram_dout0 (oram_dout0[31:0]),      
         
         // Port 1: R
         .ram_clk1 (oram_clk1),


### PR DESCRIPTION
User project can't read RAM when R/W port is enabled.

Fix confirmed with wokwi/wrapped_spell@3ef470b51660d0646d083e5d1848b68b1612827b (uncommenting line 87 in spell_test.c)